### PR TITLE
Add japanese translation

### DIFF
--- a/LocalizationEdits/Japanese/ui_settings.yaml
+++ b/LocalizationEdits/Japanese/ui_settings.yaml
@@ -1,0 +1,3 @@
+edits:
+  game_combat_execute_start_sound__header: 実行開始の効果音
+  game_combat_execute_start_sound__text: 実行ボタンをクリックしたときに効果音を鳴らします。


### PR DESCRIPTION
**Description**
The setting name and tooltip can be shown in Japanese when the player chooses Japanese in the game.

**Related Issues**
#1 