### PR TITLE
Mute sound when units do not have orders

### DIFF
--- a/Patch.cs
+++ b/Patch.cs
@@ -15,18 +15,68 @@ namespace EchKode.PBMods.SilentStart
 	{
 		[HarmonyPatch(typeof(CombatUtilities), nameof(CombatUtilities.ConfirmExecution))]
 		[HarmonyTranspiler]
-		static IEnumerable<CodeInstruction> Cu_ConfirmExecutionTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+		static IEnumerable<CodeInstruction> Cu_ConfirmExecutionTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator) =>
+			SettingsGuardTranspiler(instructions, generator, CodeInstruction.LoadField(typeof(GameSettings), nameof(GameSettings.enableExecuteSound)));
+
+		[HarmonyPatch(typeof(CIViewCombatExecution), nameof(CIViewCombatExecution.CheckAndAttemptExecution))]
+		[HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> Civce_CheckAndAttemptExecutionTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+		{
+			// Stash setting in separate variable so the dialog can discriminate where it was called from.
+			var openMethodInfo = AccessTools.DeclaredMethod(typeof(CIViewDialogConfirmation), nameof(CIViewDialogConfirmation.Open));
+			var openMatch = new CodeMatch(OpCodes.Callvirt, openMethodInfo);
+			var loadInstanceMatch = new CodeMatch(CodeInstruction.LoadField(typeof(CIViewDialogConfirmation), nameof(CIViewDialogConfirmation.ins)));
+			var loadSetting = CodeInstruction.LoadField(typeof(GameSettings), nameof(GameSettings.enableExecuteSound));
+			var storeSetting = CodeInstruction.StoreField(typeof(Patch), nameof(Patch.playSoundInDialog));
+
+			FileLog.Log("open: " + openMatch);
+			FileLog.Log("load: " + loadInstanceMatch);
+			var cm = new CodeMatcher(instructions, generator);
+			cm.End();
+			cm.MatchStartBackwards(openMatch)
+				.MatchStartBackwards(loadInstanceMatch)
+				.InsertAndAdvance(loadSetting)
+				.InsertAndAdvance(storeSetting);
+
+			return cm.InstructionEnumeration();
+		}
+
+		[HarmonyPatch(typeof(CIViewDialogConfirmation), nameof(CIViewDialogConfirmation.SetAudioEvents))]
+		[HarmonyPostfix]
+		static void Civdc_SetAudioEventsPostfix(CIViewDialogConfirmation __instance)
+		{
+			if (__instance.buttonConfirm.audio != null && __instance.buttonConfirm.audio.onClick != null)
+			{
+				__instance.buttonConfirm.audio.onClick.enabled = playSoundInDialog;
+			}
+		}
+
+		[HarmonyPatch(typeof(CIViewDialogConfirmation), nameof(CIViewDialogConfirmation.TryEntry))]
+		[HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> Civdc_TryEntryTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator) =>
+			SettingsGuardTranspiler(instructions, generator, CodeInstruction.LoadField(typeof(Patch), nameof(Patch.playSoundInDialog)));
+
+		[HarmonyPatch(typeof(CIViewDialogConfirmation), nameof(CIViewDialogConfirmation.TryExit))]
+		[HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> Civdc_TryExitTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator) =>
+			SettingsGuardTranspiler(instructions, generator, CodeInstruction.LoadField(typeof(Patch), nameof(Patch.playSoundInDialog)));
+
+		[HarmonyPatch(typeof(CIViewDialogConfirmation), nameof(CIViewDialogConfirmation.TryExit))]
+		[HarmonyPostfix]
+		static void Civdc_TryExitPostfix()
+		{
+			playSoundInDialog = true;
+		}
+
+		static IEnumerable<CodeInstruction> SettingsGuardTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator, CodeInstruction loadSetting)
 		{
 			// Guard call to play sound with settings check.
-
-			var cm = new CodeMatcher(instructions, generator);
-			var createAudioEventMethodInfo = AccessTools.DeclaredMethod(typeof(AudioUtility), nameof(AudioUtility.CreateAudioEvent), new[]
+			var createAudioEventMatch = new CodeMatch(CodeInstruction.Call(typeof(AudioUtility), nameof(AudioUtility.CreateAudioEvent), new[]
 			{
 				typeof(string)
-			});
-			var createAudioEventMatch = new CodeMatch(OpCodes.Call, createAudioEventMethodInfo);
-			var loadSetting = CodeInstruction.LoadField(typeof(GameSettings), nameof(GameSettings.enableExecuteSound));
+			}));
 
+			var cm = new CodeMatcher(instructions, generator);
 			cm.Start();
 			cm.MatchEndForward(createAudioEventMatch)
 				.Advance(2)
@@ -37,5 +87,7 @@ namespace EchKode.PBMods.SilentStart
 
 			return cm.InstructionEnumeration();
 		}
+
+		public static bool playSoundInDialog = true;
 	}
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 priority: 0
 colorHue: 0.5
 id: dev.echkode.pbmods.silentstart
-ver: 1.0
+ver: 1.1
 url: 
 includesConfigOverrides: true
 includesConfigEdits: false

--- a/project.yaml
+++ b/project.yaml
@@ -1,6 +1,27 @@
 workshop: 
 configEdits: 
-textEdits: 
+textEdits:
+  languages:
+    English:
+      sectors:
+        ui_settings:
+          text:
+            game_combat_execute_start_sound__header:
+              text: Execute start sound
+              textSource: 
+            game_combat_execute_start_sound__text:
+              text: Play sound when execute button is clicked.
+              textSource: 
+    Japanese:
+      sectors:
+        ui_settings:
+          text:
+            game_combat_execute_start_sound__header:
+              text: 実行開始の効果音
+              textSource: 
+            game_combat_execute_start_sound__text:
+              text: 実行ボタンをクリックしたときに効果音を鳴らします。
+              textSource: 
 assetBundles: 
 libraryDLLs:
   files:


### PR DESCRIPTION
A warning dialog pops up when you try to execute a turn with units that have no actions. This dialog will play a few different sounds when it is dimissed. This commits adds those sounds to the list that's muted when the game option is toggled off.